### PR TITLE
Move variable to database instead of subscription.

### DIFF
--- a/redis.tf
+++ b/redis.tf
@@ -3,7 +3,6 @@ resource "rediscloud_subscription" "subscription" {
   name                          = var.project_subscription_name
   memory_storage                = var.memory_storage
   persistent_storage_encryption = var.persistent_storage_encryption
-  enable_tls                    = var.enable_tls
 
   cloud_provider {
     provider         = var.cloud_provider
@@ -25,6 +24,7 @@ resource "rediscloud_subscription" "subscription" {
     throughput_measurement_value = var.throughput_measurement_value
     password                     = var.redis_db_password
     replication                  = var.replication
+    enable_tls                   = var.enable_tls
 
     alert {
       name  = var.db_alert_name


### PR DESCRIPTION
When it's on the subscription it errors out:

```bash
(⎈ |prod2:dapper)➜  testing terraform plan
╷
│ Error: Unsupported argument
│
│   on .terraform/modules/nfl-staging-redis-db/redis.tf line 6, in resource "rediscloud_subscription" "subscription":
│    6:   enable_tls                    = var.enable_tls
│
│ An argument named "enable_tls" is not expected here.
```

When it's on the database:

```bash
(⎈ |prod2:dapper)➜  testing terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # random_password.redis_password will be created
  + resource "random_password" "redis_password" {
      + id          = (known after apply)
      + length      = 20
      + lower       = true
      + min_lower   = 0
      + min_numeric = 0
      + min_special = 0
      + min_upper   = 0
      + number      = true
      + result      = (sensitive value)
      + special     = false
      + upper       = true
    }

  # module.nfl-staging-redis-db.rediscloud_subscription.subscription will be created
  + resource "rediscloud_subscription" "subscription" {
      + id                            = (known after apply)
      + memory_storage                = "ram"
      + name                          = "dl-darron-staging"
      + payment_method_id             = (known after apply)
      + persistent_storage_encryption = true

      + cloud_provider {
          + cloud_account_id = "1"
          + provider         = "GCP"

          + region {
              + multiple_availability_zones  = true
              + networking_deployment_cidr   = "192.168.41.0/24"
              + networks                     = (known after apply)
              + preferred_availability_zones = []
              + region                       = "us-west1"
            }
        }

      + database {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```