### PR TITLE
Update subscription reference to work

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,5 +10,5 @@ output "public_endpoint" {
 
 output "subscription_id" {
   description = "Subscription identifier for the redis cluster"
-  value       = rediscloud_subscription.id
+  value       = rediscloud_subscription.subscription.id
 }


### PR DESCRIPTION
The output for the subscription id didn't reference the named resource.  This fixes that issue.