### PR TITLE
Upgrade to latest version of rediscloud TF provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     rediscloud = {
       source  = "RedisLabs/rediscloud"
-      version = "= 0.2.8"
+      version = "= 0.2.9"
     }
   }
 }


### PR DESCRIPTION
New TF provider version was released nine days ago.