### PR TITLE
Removes cloud_provider variable (always GCP), persistent_storage_encryption

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,3 +6,7 @@ terraform {
     }
   }
 }
+
+locals {
+  cloud_provider = "GCP"
+}

--- a/redis.tf
+++ b/redis.tf
@@ -1,11 +1,10 @@
 
 resource "rediscloud_subscription" "subscription" {
-  name                          = var.project_subscription_name
-  memory_storage                = var.memory_storage
-  persistent_storage_encryption = var.persistent_storage_encryption
+  name           = var.project_subscription_name
+  memory_storage = var.memory_storage
 
   cloud_provider {
-    provider         = var.cloud_provider
+    provider         = local.cloud_provider
     cloud_account_id = 1
     region {
       region                       = var.region
@@ -31,7 +30,4 @@ resource "rediscloud_subscription" "subscription" {
       value = var.db_alert_value
     }
   }
-
 }
-
-

--- a/variables.tf
+++ b/variables.tf
@@ -70,10 +70,11 @@ variable "redis_db_password" {
   type        = string
 }
 
-variable "persistent_storage_encryption" {
-  type    = bool
-  default = true
-}
+# this setting is irrelevant in GCP and can actually cause problems
+# variable "persistent_storage_encryption" {
+#   type    = bool
+#   default = true
+# }
 
 variable "enable_tls" {
   type    = bool
@@ -90,11 +91,6 @@ variable "db_alert_value" {
   description = "Set DB Alert value"
   type        = string
   default     = "50"
-}
-
-variable "cloud_provider" {
-  description = "Set Cloud Provider to use"
-  type        = string
 }
 
 variable "replication" {


### PR DESCRIPTION
After conferring with RedisLabs, the `persistent_storage_encryption` configuration option is only relevant on AWS, as GCP always encrypts.  Since this is a GCP project, we are going to remove the `cloud_provider` option for brevity and remove this option since it's not relevant and can cause problems downstream.