### PR TITLE
Ignores changes to persistent_storage_encryption

### DIFF
--- a/redis.tf
+++ b/redis.tf
@@ -30,4 +30,10 @@ resource "rediscloud_subscription" "subscription" {
       value = var.db_alert_value
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      persistent_storage_encryption # this setting is irrelevant in GCP, and this resource always returns `false` even though it's `true`
+    ]
+  }
 }


### PR DESCRIPTION
GCP always encrypts (whereas AWS does not).  However, the `rediscloud_subscription` module always returns `false` for `persistent_storage_encryption` when it should be true.  We verified with RedisLabs that this value can be safely ignored.